### PR TITLE
Use official PHP 7-Apache Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,2 @@
-FROM ubuntu:12.04
-
-# Install dependencies
-RUN apt-get update -y
-RUN apt-get install -y git curl apache2 php5 libapache2-mod-php5 php5-mcrypt php5-mysql
-
-# Install app
-RUN rm -rf /var/www/*
-ADD src /var/www
-
-# Configure apache
-RUN a2enmod rewrite
-RUN chown -R www-data:www-data /var/www
-ENV APACHE_RUN_USER www-data
-ENV APACHE_RUN_GROUP www-data
-ENV APACHE_LOG_DIR /var/log/apache2
-
-EXPOSE 80
-
-CMD ["/usr/sbin/apache2", "-D",  "FOREGROUND"]
+FROM php:7-apache
+COPY src/ /var/www/html/


### PR DESCRIPTION
Update from Ubuntu 12.04 which was EOL in April 2017 to Debian Jessie-based image
Update from PHP 5.6 to 7.1. See http://php.net/supported-versions.php for more info

The [docs](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html) will need to be updated as well since they refer to Ubuntu 12.04.