### PR TITLE
Migrate to Amazon Linux 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM ubuntu:12.04
+FROM amazonlinux:2
 
 # Install dependencies
-RUN apt-get update -y
-RUN apt-get install -y git curl apache2 php5 libapache2-mod-php5 php5-mcrypt php5-mysql
+RUN yum install -y \
+    curl \
+    httpd \
+    php \
+ && ln -s /usr/sbin/httpd /usr/sbin/apache2
 
 # Install app
-RUN rm -rf /var/www/*
-ADD src /var/www
+RUN rm -rf /var/www/html/* && mkdir -p /var/www/html
+ADD src /var/www/html
 
 # Configure apache
-RUN a2enmod rewrite
-RUN chown -R www-data:www-data /var/www
-ENV APACHE_RUN_USER www-data
-ENV APACHE_RUN_GROUP www-data
+RUN chown -R apache:apache /var/www
+ENV APACHE_RUN_USER apache
+ENV APACHE_RUN_GROUP apache
 ENV APACHE_LOG_DIR /var/log/apache2
 
 EXPOSE 80


### PR DESCRIPTION
*Description of changes:*
This commit moves the image to `amazonlinux:2` instead of `ubuntu:12.04` and preserves compatibility with existing task definitions (symlinking `/usr/sbin/httpd` to `/usr/sbin/apache2` and supporting the same volume structure).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
