### PR TITLE
shifted Dockerfile amazonlinux2 base from DockerHub to ECR Public Gallery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 # Install dependencies
 RUN yum install -y \


### PR DESCRIPTION

*Issue*  #47 

*Description of changes:*
Changes the Base image of the Dockerfile to use `amazonlinux:2` from the [ECR Public Gallery](https://gallery.ecr.aws/amazonlinux/amazonlinux) to avoid build fails in case of having reach the Docker Hub limit for anonymous pulls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
